### PR TITLE
Allow compiling in MXML 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The program "sj" just does a few things:
 
 ## requires
 
-  * mxml 2.8
+  * mxml 2.8 or 3.x
   * libbsd (for GNU-systems like Linux)
   * [ucspi-tcp](http://cr.yp.to/ucspi-tcp.html)
   * [ucspi-tools](https://github.com/younix/ucspi)

--- a/iqd.c
+++ b/iqd.c
@@ -67,7 +67,7 @@ recv_iq(char *tag, void *data)
 	if (tree == NULL) err(EXIT_FAILURE, "unable to load xml base tag");
 
 	mxmlLoadString(tree, tag, MXML_NO_CALLBACK);
-	if ((node = tree->child) == NULL)
+	if ((node = mxmlGetFirstChild(tree)) == NULL)
 		goto err;
 
 	if ((tag_name = mxmlGetElement(node)) == NULL) goto err;
@@ -138,7 +138,7 @@ recv_iq(char *tag, void *data)
 		perror(__func__);
  out:
 	errno = 0;
-	mxmlDelete(tree->child);
+	mxmlDelete(node);
 }
 
 static void

--- a/messaged.c
+++ b/messaged.c
@@ -210,7 +210,7 @@ recv_message(char *tag, void *data)
 	if (tree == NULL) err(EXIT_FAILURE, "unable to load xml base");
 
 	mxmlLoadString(tree, tag, MXML_NO_CALLBACK);
-	if ((node = tree->child) == NULL)
+	if ((node = mxmlGetFirstChild(tree)) == NULL)
 		goto err;
 
 	if ((tag_name = mxmlGetElement(node)) == NULL) goto err;
@@ -226,7 +226,7 @@ recv_message(char *tag, void *data)
 	if (c == NULL)
 		c = add_contact(ctx, from);
 
-	body = mxmlFindElement(node->child, tree, "body", NULL, NULL,
+	body = mxmlFindElement(mxmlGetFirstChild(node), tree, "body", NULL, NULL,
 	    MXML_NO_DESCEND);
 	if (body == NULL)
 		goto err;
@@ -235,7 +235,7 @@ recv_message(char *tag, void *data)
 	write(c->out, prompt, strlen(prompt));
 
 	/* concatinate all text peaces */
-	for (mxml_node_t *txt = body->child; txt != NULL;
+	for (mxml_node_t *txt = mxmlGetFirstChild(body); txt != NULL;
 	    txt = mxmlGetNextSibling(txt)) {
 		int space = 0;
 		const char *t = mxmlGetText(txt, &space);
@@ -247,7 +247,7 @@ recv_message(char *tag, void *data)
  err:
 	if (errno != 0)
 		perror(__func__);
-	mxmlDelete(tree->child);
+	mxmlDelete(node);
 }
 
 static bool

--- a/presenced.c
+++ b/presenced.c
@@ -225,18 +225,17 @@ recv_presence(char *tag, void *data)
 	if (tree == NULL) err(EXIT_FAILURE, "%s: no xml tree found", __func__);
 	mxmlLoadString(tree, tag, MXML_NO_CALLBACK);
 
-	if (tree->child->next == NULL) goto err;
-	node = tree->child->next;
+	if ((node = mxmlGetNextSibling(mxmlGetFirstChild(tree))) == NULL) goto err;
 	if ((tag_name = mxmlGetElement(node)) == NULL) goto err;
 	if (strcmp("presence", tag_name) != 0)
 		goto err;
 
-	if ((from = mxmlElementGetAttr(tree->child->next, "from")) == NULL)
+	if ((from = mxmlElementGetAttr(node, "from")) == NULL)
 		goto err;
 
 	/* The presence of the 'type' attribute indicates offline.
 	   The lack of it indicates online. */
-	if (mxmlElementGetAttr(tree->child->next, "type"))
+	if (mxmlElementGetAttr(node, "type"))
 		is_online = false;
 	else
 		is_online = true;
@@ -277,7 +276,7 @@ recv_presence(char *tag, void *data)
  err:
 	if (errno != 0)
 		perror(__func__);
-	mxmlDelete(tree->child->next);
+	mxmlDelete(node);
 }
 
 static void

--- a/roster.c
+++ b/roster.c
@@ -30,7 +30,7 @@ static bool
 result(mxml_node_t *iq)
 {
 	if (iq == NULL) return false;
-	if (iq->child != NULL) return false;
+	if (mxmlGetFirstChild(iq) != NULL) return false;
 
 	return true;
 }
@@ -63,9 +63,9 @@ list(mxml_node_t *iq)
 	mxml_node_t *item = NULL;
 
 	if (iq == NULL) return false;
-	if (iq->child == NULL) return false;
+	if ((item = mxmlGetFirstChild(iq)) == NULL) return false;
 
-	for (item = iq->child->child; item != NULL; item = item->next) {
+	for (item = mxmlGetFirstChild(item); item != NULL; item = mxmlGetNextSibling(item)) {
 		const char *name = mxmlElementGetAttr(item, "name");
 		const char *jid = mxmlElementGetAttr(item, "jid");
 		const char *sub = mxmlElementGetAttr(item, "subscription");
@@ -172,10 +172,10 @@ main(int argc, char *argv[])
 	if (unlink(path_in) == -1) goto err;
 
 	if (list_flag)
-		if (list(tree->child->next) == false) return EXIT_FAILURE;
+		if (list(mxmlGetNextSibling(mxmlGetFirstChild(tree))) == false) return EXIT_FAILURE;
 
 	if (add_flag)
-		if (result(tree->child->next) == false) return EXIT_FAILURE;
+		if (result(mxmlGetNextSibling(mxmlGetFirstChild(tree))) == false) return EXIT_FAILURE;
 
 	return EXIT_SUCCESS;
  err:

--- a/sj.c
+++ b/sj.c
@@ -261,7 +261,7 @@ server_tag(char *tag, void *data)
 	mxmlLoadString(tree, tag, MXML_NO_CALLBACK);
 	/* End of HACK */
 
-	if ((node = tree->child->next) == NULL)
+	if ((node = mxmlGetNextSibling(mxmlGetFirstChild(tree))) == NULL)
 		err(EXIT_FAILURE, "no node found");
 
 	const char *tag_name = mxmlGetElement(node);
@@ -345,7 +345,7 @@ server_tag(char *tag, void *data)
 	if (errno != 0)
 		perror(__func__);
  out:
-	mxmlDelete(tree->child->next);
+	mxmlDelete(node);
 }
 
 /*

--- a/xmpp_time.c
+++ b/xmpp_time.c
@@ -77,7 +77,7 @@ main(int argc, char *argv[])
 	mxmlLoadFile(tree, stdin, MXML_NO_CALLBACK);
 
 	/* check iq tag */
-	if ((node = tree->child) == NULL)
+	if ((node = mxmlGetFirstChild(tree)) == NULL)
 		errx(EXIT_FAILURE, "unable to parse xml data");
 
 	if ((id = mxmlElementGetAttr(node, "id")) == NULL)


### PR DESCRIPTION
This fixes compilation with MXML 3.x

The only change needed is switching the `->child` and `->next` to the dedicated functions for that purpose (according to MXML documentation)

>     Note: Version 3.0 hides the definition of the mxml_node_t structure, requiring the use of the various accessor functions that were introduced in version 2.0.

This should still work in 2.8; those functions were added in 2.7.

(As of 2023-07-16, I haven't tested that this actually works, but it does compile!)