### PR TITLE
test: Fix name of xmpp_time command

### DIFF
--- a/tests/test.sh
+++ b/tests/test.sh
@@ -20,7 +20,7 @@ tmpdir=$(mktemp -d sj_tests_XXXXXX)
 
 # prepare
 mkdir "$tmpdir/ext"
-ln -s '../../../xmpp:time' "$tmpdir/ext/urn:xmpp:time"
+ln -s '../../../xmpp_time' "$tmpdir/ext/urn:xmpp:time"
 touch "$tmpdir/in"
 
 # start iqd with input


### PR DESCRIPTION
I'm still seeing 
```
recv_message: Invalid argument
recv_message: Invalid argument
recv_message: Invalid argument
ok 4 - messaged stating and ending
```

and setting POSIXLY_CORRECT=1 doesn't help.
```
recv_message: Invalid argument
recv_message: Invalid argument
recv_message: Invalid argument
ok 4 - messaged
```

(but this makes it so the tests pass)