### PR TITLE
Message receiving: Fix for some messages from go-sendxmpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ presence
 roster -a other@server.com -n joe
 
 # subscribe his online status
-presence -to other@server.com subscribe
+presence -t other@server.com subscribe
 
 # let him see your online status
-presence -to other@server.com subscribed
+presence -t other@server.com subscribed
 
 # view buddies on your roster
 roster

--- a/messaged.c
+++ b/messaged.c
@@ -226,8 +226,8 @@ recv_message(char *tag, void *data)
 	if (c == NULL)
 		c = add_contact(ctx, from);
 
-	body = mxmlFindElement(mxmlGetFirstChild(node), tree, "body", NULL, NULL,
-	    MXML_NO_DESCEND);
+	body = mxmlFindElement(tree, tree, "body", NULL, NULL,
+	    MXML_DESCEND);
 	if (body == NULL)
 		goto err;
 

--- a/tests/message.xml
+++ b/tests/message.xml
@@ -9,3 +9,4 @@
 <message from='eve@server.org' to='bob@server.org' type='chat' id='12345'>
 	<active xmlns='http://jabber.org/protocol/chatstates'/>
 </message>
+<message to='bob@server.org/sj' xml:lang='en' id='9a75c46543fd78fd' type='chat' from='cari@server.org/go-sendxmpp.a5306d3b'><body>consectetur</body><stanza-id id='0OzoyIscRghzUgvc3O03UZEr' xmlns='urn:xmpp:sid:0' by='bob@server.org'/></message>

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -4,7 +4,7 @@ export MALLOC_OPTIONS="S"
 
 . ./tap-functions -u
 
-plan_tests 11
+plan_tests 12
 
 # prepare
 
@@ -51,6 +51,9 @@ ok $? "messaged create in file as named pipe"
 
 grep -q '^....-..-.. ..:.. <eve@server.org> $' "$tmpdir/eve@server.org/out"
 ok $? "empty messages are accepted"
+
+grep -q '^....-..-.. ..:.. <cari@server.org/.*> consectetur$' "$tmpdir/cari@server.org/out"
+ok $? "message without active element is accepted"
 
 #
 # presenced tests


### PR DESCRIPTION
For me, sj is only able to receive messages from libpurple (specifically chatty on Librem 5). After this PR, I can receive messages from go-sendxmpp, but only if they are directly address to this client.


* `echo "SJ will miss this" | go-sendxmpp me@example.org` -- doesn't work
* `echo "SJ will receive this" | go-sendxmpp me@example.org/sj` -- works

I was having problems receiving messages, but I think that was due to misusing `presence`. Documentation has been updated.