### PR TITLE
Bugfixes: Sending messages and space in $SJ_DIR

### DIFF
--- a/messaged.c
+++ b/messaged.c
@@ -179,8 +179,11 @@ send_message(struct context *ctx, struct contact *con)
 		return true;
 
 	buf[size] = '\0';
-	if (buf[size - 1] == '\n')
+	/* Trim trailing whitespace/control characters. */
+	while (buf[size - 1] <= ' ') {
 		buf[size - 1] = '\0';
+		size--;
+	}
 	msg_send(ctx, buf, con->name);
 
 	/* Write message to the out file, that the use see its own messages. */

--- a/sj.c
+++ b/sj.c
@@ -201,14 +201,14 @@ start_sub_proccess(struct context *ctx)
 {
 	char cmd[BUFSIZ];
 
-	snprintf(cmd, sizeof cmd, "exec messaged -j %s@%s -d %s",
+	snprintf(cmd, sizeof cmd, "exec messaged -j %s@%s -d '%s'",
 	    ctx->user, ctx->server, ctx->dir);
 	if ((ctx->fh_msg = popen(cmd, "w")) == NULL) goto err;
 
-	snprintf(cmd, sizeof cmd, "exec presenced -d %s", ctx->dir);
+	snprintf(cmd, sizeof cmd, "exec presenced -d '%s'", ctx->dir);
 	if ((ctx->fh_pre = popen(cmd, "w")) == NULL) goto err;
 
-	snprintf(cmd, sizeof cmd, "exec iqd -d %s", ctx->dir);
+	snprintf(cmd, sizeof cmd, "exec iqd -d '%s'", ctx->dir);
 	if ((ctx->fh_iq = popen(cmd, "w")) == NULL) goto err;
 
 	return true;


### PR DESCRIPTION
Closes #13  (message escaping for < and &)

Closes #14 (allow space in SJ_DIR)

Also fixes a bug I noticed where the null byte was getting written to the out log when sending messages with a trailing newline.